### PR TITLE
refactor: optimize CompleteApiLogItemEvent for single dispatch with bulk model operations

### DIFF
--- a/src/Events/CompleteApiLogItemEvent.php
+++ b/src/Events/CompleteApiLogItemEvent.php
@@ -6,6 +6,7 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Prahsys\ApiLogs\Data\ApiLogData;
+use Prahsys\ApiLogs\Services\ApiLogItemTracker;
 
 class CompleteApiLogItemEvent
 {
@@ -16,13 +17,13 @@ class CompleteApiLogItemEvent
      *
      * @param  string  $requestId  The correlation key/request ID
      * @param  string  $apiLogItemId  The ID of the ApiLogItem model
-     * @param  array  $models  Array of models to associate with the API log item
+     * @param  ApiLogItemTracker  $tracker  The tracker instance with all models for this request
      * @param  ApiLogData|null  $apiLogData  The API log data to process through pipelines
      */
     public function __construct(
         public string $requestId,
         public string $apiLogItemId,
-        public array $models,
+        public ApiLogItemTracker $tracker,
         public ?ApiLogData $apiLogData = null
     ) {}
 }

--- a/src/Http/Middleware/ApiLogMiddleware.php
+++ b/src/Http/Middleware/ApiLogMiddleware.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Prahsys\ApiLogs\Data\ApiLogData;
 use Prahsys\ApiLogs\Events\CompleteApiLogItemEvent;
-use Prahsys\ApiLogs\Models\ApiLogItem;
 use Prahsys\ApiLogs\Services\ApiLogItemService;
 use Prahsys\ApiLogs\Services\ApiLogItemTracker;
 use Symfony\Component\HttpFoundation\Response;
@@ -154,7 +153,7 @@ class ApiLogMiddleware
     }
 
     /**
-     * Fire the CompleteIdempotentRequestEvent with tracked models and ApiLogData.
+     * Fire the CompleteApiLogItemEvent with tracker instance and ApiLogData.
      */
     public function fireCompleteEvent(ApiLogData $apiLogData, $apiLogItem): void
     {
@@ -162,20 +161,18 @@ class ApiLogMiddleware
             return;
         }
 
-        // Get tracked models
+        // Get the tracker instance with all tracked models for this request
         $tracker = app(ApiLogItemTracker::class);
-        $models = $tracker->getModelsForRequest($apiLogData->id);
 
-        // Fire event with ApiLogData
+        // Fire event with ApiLogData and tracker instance
         CompleteApiLogItemEvent::dispatch(
             $apiLogData->id,
             $apiLogItem->id,
-            $models->toArray(),
+            $tracker, // Pass the tracker instance instead of models array
             $apiLogData
         );
 
-        // Clear the tracker for this request ID
-        $tracker->clearRequest($apiLogData->id);
+        // Don't clear the tracker here - let the event listener handle it
     }
 
     /**

--- a/src/Services/ApiLogItemTracker.php
+++ b/src/Services/ApiLogItemTracker.php
@@ -59,4 +59,12 @@ class ApiLogItemTracker
             unset($this->modelsByRequest[$requestId]);
         }
     }
+
+    /**
+     * Clear all tracked models for all requests
+     */
+    public function clearAll(): void
+    {
+        $this->modelsByRequest = [];
+    }
 }

--- a/tests/Unit/ApiLogMiddlewareTest.php
+++ b/tests/Unit/ApiLogMiddlewareTest.php
@@ -246,10 +246,6 @@ test('fireCompleteEvent fires event with tracked models and ApiLogData', functio
         ->with($this->requestId)
         ->andReturn($mockModels);
 
-    $mockTracker->shouldReceive('clearRequest')
-        ->once()
-        ->with($this->requestId);
-
     // Mock the app() call to return our mock tracker
     $this->app->instance(ApiLogItemTracker::class, $mockTracker);
 
@@ -264,7 +260,7 @@ test('fireCompleteEvent fires event with tracked models and ApiLogData', functio
     Event::assertDispatched(CompleteApiLogItemEvent::class, function ($event) use ($apiLogData) {
         return $event->requestId === $this->requestId
             && $event->apiLogItemId === 'idempotent-request-id'
-            && count($event->models) === 2
+            && $event->tracker->getModelsForRequest($this->requestId)->count() === 2
             && $event->apiLogData === $apiLogData;
     });
 });

--- a/tests/Unit/PipelineIntegrationTest.php
+++ b/tests/Unit/PipelineIntegrationTest.php
@@ -34,7 +34,7 @@ beforeEach(function () {
 
 it('processes full pipeline and redacts sensitive data', function () {
     // Create a fresh manager to test functionality
-    $manager = new ApiLogPipelineManager();
+    $manager = new ApiLogPipelineManager;
     $manager->addChannel('test_redacted', [
         CommonHeaderFieldsRedactor::class,
         CommonBodyFieldsRedactor::class,
@@ -85,7 +85,7 @@ it('processes full pipeline and redacts sensitive data', function () {
 
 it('preserves all data in raw pipeline', function () {
     // Create a fresh manager to test functionality
-    $manager = new ApiLogPipelineManager();
+    $manager = new ApiLogPipelineManager;
     $manager->addChannel('test_raw', []); // No redactors
 
     // Test that channels are properly configured


### PR DESCRIPTION
- Change event to fire once per request instead of multiple times per outbound call
- Pass ApiLogItemTracker instance instead of models array for complete context
- Remove event firing from GuzzleApiLogMiddleware to prevent duplicate events
- Implement bulk model validation and attachment in CompleteApiLogItemListener
- Add clearAll() method to ApiLogItemTracker for efficient cleanup
- Reduce database queries from N individual operations to bulk operations per model class
